### PR TITLE
fix: appName is not translated

### DIFF
--- a/deepin-feedback
+++ b/deepin-feedback
@@ -10,7 +10,7 @@ if [[ -n "$from_app" && ! -n "$from_dbus" ]]; then
 fi
 export TEXTDOMAIN=deepin-feedback
 # 应用名
-app_name="Deepin User Feedback"
+app_name=$(gettext "Deepin User Feedback")
 # 应用图标
 app_icon="deepin-feedback"
 # 授权前提示


### PR DESCRIPTION
it was introduced in https://github.com/linuxdeepin/deepin-feedback/commit/5ed5df6d12f53c518de5c35184965c04a291bfda
    
Issue: https://github.com/linuxdeepin/developer-center/issues/7889